### PR TITLE
Move the suicide refund address check.

### DIFF
--- a/core/src/evm/interpreter/mod.rs
+++ b/core/src/evm/interpreter/mod.rs
@@ -989,11 +989,7 @@ impl<Cost: CostType> Interpreter<Cost> {
             }
             instructions::SUICIDE => {
                 let address = self.stack.pop_back();
-                let mut refund_address = u256_to_address(&address);
-                if !refund_address.is_valid_address() {
-                    refund_address = self.params.address.clone();
-                }
-                context.suicide(&refund_address)?;
+                context.suicide(&u256_to_address(&address))?;
                 return Ok(InstructionResult::StopExecution);
             }
             instructions::LOG0

--- a/core/src/executive/internal_contract/impls/admin.rs
+++ b/core/src/executive/internal_contract/impls/admin.rs
@@ -94,9 +94,13 @@ pub fn suicide(
             &sponsor_balance_for_collateral,
         )?;
     }
-    if refund_address == contract_address {
-        // This is the corner case that the sponsor of the contract is itself.
+    if !refund_address.is_valid_address() || refund_address == contract_address
+    {
+        // This is the corner case that the sponsor of the contract is itself,
+        // or the sponsor is invalid.
         // When destroying, the balance will be burnt.
+        // The case when sponsor is invalid can never happen but we add a check
+        // anyways as defensive design.
         state.sub_balance(
             contract_address,
             &balance,


### PR DESCRIPTION
I think this is better and more readable since
1. we have two different suicide entrances (internal contract or suicide op code)
2. the special case handling is closer to the logic processing it.